### PR TITLE
fix: Use the pluginhelper logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 .env
 .vscode/
 .idea/
+cnpg-i-hello-world

--- a/cmd/plugin/plugin.go
+++ b/cmd/plugin/plugin.go
@@ -21,6 +21,11 @@ func NewCmd() *cobra.Command {
 		return nil
 	})
 
+	// If you want to provide your own logr.Logger here, inject it into a context.Context
+	// with logr.NewContext(ctx, logger) and pass it to cmd.SetContext(ctx)
+
+	// Additional custom behaviour can be added by wrapping cmd.PersistentPreRun or cmd.Run
+
 	cmd.Use = "plugin"
 
 	return cmd

--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/log"
+	"github.com/cloudnative-pg/cnpg-i-machinery/pkg/logging"
 	"github.com/cloudnative-pg/cnpg-i-machinery/pkg/pluginhelper"
 	"github.com/cloudnative-pg/cnpg-i/pkg/lifecycle"
 
@@ -75,7 +75,7 @@ func (impl Implementation) reconcileMetadata(
 	ctx context.Context,
 	request *lifecycle.OperatorLifecycleRequest,
 ) (*lifecycle.OperatorLifecycleResponse, error) {
-	logger := log.FromContext(ctx).WithName("cnpg_i_example_lifecyle")
+	logger := logging.FromContext(ctx).WithName("cnpg_i_example_lifecyle")
 	helper, err := pluginhelper.NewDataBuilder(
 		metadata.PluginName,
 		request.ClusterDefinition,
@@ -105,7 +105,7 @@ func (impl Implementation) reconcileMetadata(
 		return nil, err
 	}
 
-	logger.Debug("generated patch", "content", string(patch), "configuration", configuration)
+	logger.V(0).Info("generated patch", "content", string(patch), "configuration", configuration)
 
 	return &lifecycle.OperatorLifecycleResponse{
 		JsonPatch: patch,

--- a/main.go
+++ b/main.go
@@ -6,16 +6,10 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-
 	"github.com/cloudnative-pg/cnpg-i-hello-world/cmd/plugin"
 )
 
 func main() {
-	// TODO: customize with zap.UseFlagOptions(&zap.Options{}) and env variables
-	logger := zap.New()
-	log.SetLogger(logger)
 	rootCmd := &cobra.Command{
 		Use:   "cnpg-i-hello-world",
 		Short: "A plugin example",


### PR DESCRIPTION
The hello-world code tries to use logging from the kube controller API and CNPG's wrapper. These don't match what the pluginhelper sets up.

Use the pluginhelper's logging instead, and let the pluginhelper do the logging setup during server creation.