### PR TITLE
ci: allow renovate approve on minor, patch and digest upgrades

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,9 @@
     ":gitSignOff",
     ":semanticCommitType(chore)",
     ":labels(automated,no-issue)",
-    "regexManagers:githubActionsVersions"
+    "regexManagers:githubActionsVersions",
+    ":automergeMinor",
+    ":automergeDigest"
   ],
   "prConcurrentLimit": 5,
   "ignorePaths": [
@@ -58,7 +60,6 @@
     {
       "matchUpdateTypes": ["minor", "patch"],
       "matchCurrentVersion": "!/^0/",
-      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
Enabling the automerge configuration will allow the renovate approve bot to approve PRs opened by Renovate, while still requiring CodeOwner approval.