### PR TITLE
ci: do not fail on PRs from forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,12 @@ jobs:
         run: |
           task manifest
       - name: Publish images
+        if: |
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name.pull_request.head.repo.full_name == github.repository
         env:
           REGISTRY_USER: ${{ github.actor }}
-          REGISTRY_PASSWORD: ${{ secrets.REPO_PAT }}
+          REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
           task publish
       - name: Attach manifest to workflow run

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   release-please:
     runs-on: ubuntu-latest
@@ -32,7 +28,7 @@ jobs:
       - name: Create image and manifest
         env:
           REGISTRY_USER: ${{ github.actor }}
-          REGISTRY_PASSWORD: ${{ secrets.REPO_PAT }}
+          REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
           task publish
           task manifest
@@ -46,6 +42,8 @@ jobs:
       # TODO: remove release-as after first release. Used to set the first
       #   release version, which would default to 1.0.0. Set the version
       #   manually also for 1.0.0.
+      # We use a GitHub token with write permissions to create the release,
+      # otherwise we won't be able to trigger a new run when pushing on main.
       - name: Run release-please
         run: |
           npx release-please release-pr \

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -20,12 +20,12 @@ jobs:
       - name: Create image and manifest
         env:
           REGISTRY_USER: ${{ github.actor }}
-          REGISTRY_PASSWORD: ${{ secrets.REPO_PAT }}
+          REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
           task publish
           task manifest
       - name: Attach manifest to release
         env:
-          GITHUB_TOKEN: ${{ secrets.REPO_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           task upload-manifest-to-release

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -63,6 +63,16 @@ tasks:
     sources:
       - ./**/*.go
 
+  build-image:
+    desc: Build a container image for the plugin
+    env:
+      # renovate: datasource=git-refs depName=docker lookupName=https://github.com/purpleclay/daggerverse currentValue=main
+      DAGGER_DOCKER_SHA: dc62f69e82ec1b1d57397549acf724d91b76c5d8
+    cmds:
+      - >
+        GITHUB_REF= dagger -s call -m github.com/purpleclay/daggerverse/docker@${DAGGER_DOCKER_SHA}
+        build --dir . --platform linux/amd64 image > /dev/null
+
   ci:
     desc: Run the CI pipeline
     deps:
@@ -71,6 +81,7 @@ tasks:
       - uncommitted
       - lint
       - go-test
+      - build-image
 
   publish:
     desc: Build and publish a container image for the plugin


### PR DESCRIPTION
Reduce the need of personal access tokens, removing the one used to push images and keeping only to trigger release-please workflows. Avoid trying to push images to the repository in case of pull requests from forks, since the token has no power to do it and secrets are not available.