### PR TITLE
ci: change dagger module for go-test

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -51,15 +51,16 @@ tasks:
     desc: Run go test
     env:
       # renovate: datasource=docker depName=golang versioning=semver
-      GOLANG_IMAGE_VERSION: 1.22.5
-      # renovate: datasource=git-refs depName=gotest lookupName=https://github.com/Excoriate/daggerverse currentValue=main
-      DAGGER_GOTEST_SHA: 90a5d911a70510f9004544d4a25d39d917f1f668
+      GOLANG_IMAGE_VERSION: 1.23.1
+      # renovate: datasource=git-refs depName=go lookupName=https://github.com/sagikazarmark/daggerverse currentValue=main
+      DAGGER_GO_SHA: 89a5a332f2ad1a182e6e8172f6872c4ab3ada507
     cmds:
       - >
-        GITHUB_REF= dagger -s call -m github.com/Excoriate/daggerverse/gotest@${DAGGER_GOTEST_SHA}
-        base --image-url golang:${GOLANG_IMAGE_VERSION}
+        GITHUB_REF= dagger -s call -m github.com/sagikazarmark/daggerverse/go@${DAGGER_GO_SHA}
+        --version ${GOLANG_IMAGE_VERSION}
         with-cgo-disabled
-        run-go-test --src .
+        exec --src . --args go --args test --args './...'
+        stdout
     sources:
       - ./**/*.go
 


### PR DESCRIPTION
The module we were using doesn't exist anymore.