### PR TITLE
fix(logging): inject the logger into the Command context

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,10 +12,16 @@ import (
 )
 
 func main() {
+	cobra.EnableTraverseRunHooks = true
+
 	logFlags := &log.Flags{}
 	rootCmd := &cobra.Command{
 		Use:   "cnpg-i-hello-world",
 		Short: "A plugin example",
+		PersistentPreRun: func(cmd *cobra.Command, _ []string) {
+			logFlags.ConfigureLogging()
+			cmd.SetContext(log.IntoContext(cmd.Context(), log.GetLogger()))
+		},
 	}
 
 	logFlags.AddFlags(rootCmd.PersistentFlags())

--- a/main.go
+++ b/main.go
@@ -16,10 +16,6 @@ func main() {
 	rootCmd := &cobra.Command{
 		Use:   "cnpg-i-hello-world",
 		Short: "A plugin example",
-		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
-			logFlags.ConfigureLogging()
-			return nil
-		},
 	}
 
 	logFlags.AddFlags(rootCmd.PersistentFlags())


### PR DESCRIPTION
The `PersistentPreRunE` setup in `main.go` is unnecessary (actually ignored),
since it gets overridden downstream by `cnpg-i-machinery` function `http.CreateMainCmd`.
That method had a mistake in logging setup, which is fixed in a PR
there https://github.com/cloudnative-pg/cnpg-i-machinery/pull/169