### PR TITLE
fix(local-dev): add Kind config and registry startup to fix image pull

### DIFF
--- a/doc/dev/kind-config.yaml
+++ b/doc/dev/kind-config.yaml
@@ -1,0 +1,9 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: cnpg-i-hello-world
+containerdConfigPatches:
+  - |-
+    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."registry.dev:5000"]
+      endpoint = ["http://registry.dev:5000"]
+    [plugins."io.containerd.grpc.v1.cri".registry.configs."registry.dev:5000".tls]
+      insecure_skip_verify = true

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -18,6 +18,11 @@ fi
 # Constants
 registry_name=registry.dev
 
+if ! docker ps --format '{{.Names}}' | grep -q "^${registry_name}$"; then
+    docker start "${registry_name}" >/dev/null 2>&1 || \
+    docker run -d --restart=always -p 5000:5000 --name "${registry_name}" registry:2 >/dev/null
+fi
+
 load_image_registry() {
   local image=$1
 


### PR DESCRIPTION
This PR fixes the broken local development setup for running the  plugin with Kind and a local registry (registry.dev:5000).

Changes made:
Added a kind-config.yaml with containerdConfigPatches to configure registry.dev:5000 as an insecure mirror.

Included insecure_skip_verify = true to allow Kind to pull from the local registry without TLS.

Modified scripts/run.sh to start the local Docker registry before attempting to push and load the image into Kind.

Result:
With these changes, the plugin runs successfully in a Kind cluster, and the pod pulls the image correctly without ErrImagePull. Verified by observing expected logs from the plugin pod.

Issue (#188)